### PR TITLE
Planning update for 2017-09-01

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@ For the TAG, no First Public Working Draft transition request is required; the r
 </span>
 <span class="transwho" data-profile="FPIG-NOTE" data-notehistory="notchartered|first">
 sends a <a href="#transreq">transition request</a> to
-ph@w3.org (as Industry Lead) or wseltzer@w3.org (as Strategy Lead), cc'ing w3t-comm@w3.org and chairs@w3.org.
+jeff@w3.org (as Interim Industry Lead) or wseltzer@w3.org (as Strategy Lead), cc'ing w3t-comm@w3.org and chairs@w3.org.
 </span>
 <span class="transwho" data-profile="CR|PR|PR-OBSL|PR-RSCND|REC|OBSL|RSCND" data-cr="new|substantive|rec-update">
 sends a <a href="#transreq">transition request</a> to


### PR DESCRIPTION
Effective 1 September 2017, Jeff becomes Interim Industry Lead; replaced ph@w3.org with jeff@w3.org for FPIG transition request.
cf. https://lists.w3.org/Archives/Team/w3t/2017Aug/0051.html