### PR TITLE
Document the 7 days

### DIFF
--- a/index.html
+++ b/index.html
@@ -1297,8 +1297,8 @@ Publication</a></h2>
   <strong>Note:</strong> <span class="status-name">STATUS</span>s published through the <a href="https://github.com/w3c/echidna/wiki">W3C automatic system</a> do not need to get scheduled with the Webmaster and are not subjected to <a href="https://www.w3.org/Guide/#current">publishing moratoria</a>.
 </p>
 
-<p id='seven_days' data-profile="CR|PR">Unless exceptional circumstances, the Director requires a 7 days period between the <a href='#transreqmail'>transition request</a> and the publication.
-	This allows other Groups or outside individuals to <a href='https://www.w3.org/2018/Process-20180201/#FormalObjection'>formally object</a> to the transition within this 7 days period. Group participants
+<p id='seven_days' data-profile="CR|PR">Unless thre are exceptional circumstances, the Director requires a 7 days period between the <a href='#transreqmail'>transition request</a> and the publication.
+	This allows other Groups or outside individuals to review the transition request and may <a href='https://www.w3.org/2018/Process-20180201/#FormalObjection'>formally object</a> within this 7 days period. Group participants
 are expected to raise objections within the Group prior to the transition request.</p>
 
 <p id="title-page-date">The <a

--- a/index.html
+++ b/index.html
@@ -1297,7 +1297,7 @@ Publication</a></h2>
   <strong>Note:</strong> <span class="status-name">STATUS</span>s published through the <a href="https://github.com/w3c/echidna/wiki">W3C automatic system</a> do not need to get scheduled with the Webmaster and are not subjected to <a href="https://www.w3.org/Guide/#current">publishing moratoria</a>.
 </p>
 
-<p id='seven_days' data-profile="CR|PR">Unless thre are exceptional circumstances, the Director requires a 7 days period between the <a href='#transreqmail'>transition request</a> and the publication.
+<p id='seven_days' data-profile="CR|PR">Unless there are exceptional circumstances, the Director requires a 7 days period between the <a href='#transreqmail'>transition request</a> and the publication.
 	This allows other Groups or outside individuals to review the transition request and may <a href='https://www.w3.org/2018/Process-20180201/#FormalObjection'>formally object</a> within this 7 days period. Group participants
 are expected to raise objections within the Group prior to the transition request.</p>
 

--- a/index.html
+++ b/index.html
@@ -1297,6 +1297,10 @@ Publication</a></h2>
   <strong>Note:</strong> <span class="status-name">STATUS</span>s published through the <a href="https://github.com/w3c/echidna/wiki">W3C automatic system</a> do not need to get scheduled with the Webmaster and are not subjected to <a href="https://www.w3.org/Guide/#current">publishing moratoria</a>.
 </p>
 
+<p id='seven_days' data-profile="CR|PR">Unless exceptional circumstances, the Director requires a 7 days period between the <a href='#transreqmail'>transition request</a> and the publication.
+	This allows other Groups or outside individuals to <a href='https://www.w3.org/2018/Process-20180201/#FormalObjection'>formally object</a> to the transition within this 7 days period. Group participants
+are expected to raise objections within the Group prior to the transition request.</p>
+
 <p id="title-page-date">The <a
 href="https://www.w3.org/2005/08/01-transitions-about#DocContact">Document Contact</a> negotiates
 a publication date with the Webmaster.  Each publication request <span


### PR DESCRIPTION
Folks keep wondering why we have 7 days between transition and publication. This change is to document this requirement on CR and PR from the Director.
