### PR TITLE
clarifying

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@ The W3C Communications Team sends a
 <a href="#trans-annc">transition announcement</a>
 to w3c-ac-members@w3.org
 <span data-profile="CR|PR|PR-OBSL|PR-RSCND|REC|OBSL|RSCND" data-cr="new|substantive|rec-update|rec-amended">and chairs@w3.org</span>
-<span data-profile="CR|PR|REC" data-cr="new|substantive|rec-update|rec-amended">and on the <a href="https://www.w3.org/">W3C home page</a></span>.
+<span data-profile="FPWD|CR|PR|REC" data-cr="new|substantive|rec-update|rec-amended">and posts a homepage news on the <a href="https://www.w3.org/">W3C home page</a></span>.
 </li>
 
 <li  class="trans-announcement" data-profile="CR|PR|PR-OBSL|PR-RSCND" data-cr="new|substantive|rec-update" data-pr="new">The Chair or Team Contact(s) <span


### PR DESCRIPTION
+ "posts a homepage news" [on the W3C homepage]
Added "FPWD" to the data-profile so that HPN appears for those. (cf. feedback from François who noticed it was missing)