### PR TITLE
superfluous

### DIFF
--- a/index.html
+++ b/index.html
@@ -1263,7 +1263,7 @@ One or two sentences of description of the specification (for communication purp
 of the abstract.
 As an example, see this <a href="https://www.w3.org/TR/ttml/all/">cover page on TTML</a>.
 These cover pages, as their name suggests, let the community know about relationships among close specifications, what to use and not to use, how things
-fit together, etc. Contact the Comm Team with questions at w3t-comm@w3.org.
+fit together, etc. 
 <strong>Note:</strong> The Webmaster may also ask the Document Contact for assistance in categorizing the specification in an existing (or new) group on the TR page and assiging <a href="https://w3c.github.io/tr-pages/tags">tags</a>.
 If there is no change in the description since the previous publication, this can be omitted.
 </li>


### PR DESCRIPTION
Removed "Contact the Comm Team with questions at w3t-comm@w3.org." as it does not make sense here: apparently the two sentences are for the /TR cover page.