### PR TITLE
Note on homepage news for WDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 				 <p>Not sure what's your next step? Try our <a href='https://w3c.github.io/transitions/nextstep.html'>step finder</a> and look at <a href="https://w3c.github.io/spec-releases/milestones/">milestones calculator</a>.</p>
       </form>
 
-<h2 id="sotd">About This Document</h2>
+gid="sotd">About This Document</h2>
 
 <p>This resource describes the internal W3C Technical Report
 publication processes.  A <a
@@ -627,6 +627,8 @@ send any Member-confidential information to a public list.</li>
 If this publication is the result
 of <a href="https://www.w3.org/2019/Process-20190301/#recs-and-notes">returning a document to a Working Group for further work</a>, the
 Communications Team announces that to w3c-ac-members@w3.org and chairs@w3.org.</li>
+	
+<li><strong>Note:</strong> Since September 2015, the Communications Team no longer posts homepage news for regular WDs, unless explicitely requested.</li>
 </ul>
 </dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@ wisdom of the W3C Group Chairs and other collaborators.</p>
 				 <p>Not sure what's your next step? Try our <a href='https://w3c.github.io/transitions/nextstep.html'>step finder</a> and look at <a href="https://w3c.github.io/spec-releases/milestones/">milestones calculator</a>.</p>
       </form>
 
-gid="sotd">About This Document</h2>
+<h2 id="sotd">About This Document</h2>
 
 <p>This resource describes the internal W3C Technical Report
 publication processes.  A <a


### PR DESCRIPTION
I'd like a note under "Publication and Transition Announcement" to clarify that since September 2015 we no longer do homepage news for regular WDs, unless explicitely requested.