### PR TITLE
WD and FPWD announcement

### DIFF
--- a/index.html
+++ b/index.html
@@ -631,9 +631,9 @@ send any Member-confidential information to a public list.</li>
 <li class="trans-announcement"  data-profile="WD|CR|WG-NOTE" data-cr="new">
 If this publication is the result
 of <a href="https://www.w3.org/2019/Process-20190301/#recs-and-notes">returning a document to a Working Group for further work</a>, the
-Communications Team announces that to w3c-ac-members@w3.org and chairs@w3.org.</li>
-	
-<li><strong>Note:</strong> Since September 2015, the Communications Team no longer posts homepage news for regular WDs, unless explicitely requested.</li>
+Communications Team announces that to w3c-ac-members@w3.org and chairs@w3.org.
+
+<p><strong>Note:</strong> Since September 2015, the Communications Team no longer posts homepage news for regular WDs, unless explicitely requested.</p></li>
 </ul>
 </dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@ If this publication is the result
 of <a href="https://www.w3.org/2019/Process-20190301/#recs-and-notes">returning a document to a Working Group for further work</a>, the
 Communications Team announces that to w3c-ac-members@w3.org and chairs@w3.org.
 
-<p><strong>Note:</strong> Since September 2015, the Communications Team no longer posts homepage news for regular WDs, unless explicitely requested.</p></li>
+<p  data-profile="WD"><strong>Note:</strong> Since September 2015, the Communications Team no longer posts homepage news for regular WDs, unless explicitely requested.</p></li>
 </ul>
 </dd>
 </dl>
@@ -1270,7 +1270,7 @@ One or two sentences of description of the specification (for communication purp
 of the abstract.
 As an example, see this <a href="https://www.w3.org/TR/ttml/all/">cover page on TTML</a>.
 These cover pages, as their name suggests, let the community know about relationships among close specifications, what to use and not to use, how things
-fit together, etc. 
+fit together, etc.
 <strong>Note:</strong> The Webmaster may also ask the Document Contact for assistance in categorizing the specification in an existing (or new) group on the TR page and assiging <a href="https://w3c.github.io/tr-pages/tags">tags</a>.
 If there is no change in the description since the previous publication, this can be omitted.
 </li>

--- a/index.html
+++ b/index.html
@@ -606,6 +606,11 @@ Publication <span
 class="rfc2119">SHOULD</span> precede the transition announcement by
 only a small amount of time.</li>
 
+<li class="trans-announcement"  data-profile="FPWD">
+	The W3C Communications Team makes an
+	announcement on the <a href="https://www.w3.org/">W3C home page</a>.
+</li>
+
 <li class="trans-announcement"  data-profile="CR|PR|PR-OBSL|PR-RSCND|REC|OBSL|RSCND" data-cr="new|substantive|rec-update|rec-amended">
 The W3C Communications Team sends a
 <a href="#trans-annc">transition announcement</a>


### PR DESCRIPTION
Replaces #219 (only homepage news announcement for FPWD)
Tweaks #222 so that the Note only appears if WD


