### PR TITLE
No AC announcement for first public drafts

### DIFF
--- a/index.html
+++ b/index.html
@@ -647,7 +647,7 @@ is cited from the review form.
 At the current time, WBS review forms are generated from
 installed documents, but before the Webmaster completes
 publication.</span></li>
-<li  class="transannc-draft" data-profile="FPWD|FPIG-NOTE|FPWG-NOTE|CR|PR|REC|PR-OBSL|PR-RSCND|OBSL|RSCND" data-cr="new|snapshot|rec-update|rec-amended">The
+<li  class="transannc-draft" data-profile="CR|PR|REC|PR-OBSL|PR-RSCND|OBSL|RSCND" data-cr="new|snapshot|rec-update|rec-amended">The
 <a href="https://www.w3.org/2005/08/01-transitions-about#DocContact">Document Contact</a> sends a draft <a href="#trans-annc">transition announcement</a>
 to the Communications Team at w3t-comm@w3.org.
 <span  data-profile="CR" data-cr="new">If the publication is the result


### PR DESCRIPTION
Unless I'm mistaken, we don't send an announcement to the AC for first public Working Draft or first public Notes.
