### PR TITLE
page-break-inside was replaced by break-inside

### DIFF
--- a/nextstep.html
+++ b/nextstep.html
@@ -29,7 +29,7 @@
 			padding: .5em;
 			border: .5em;
 			border-left-style: solid;
-			page-break-inside: avoid;
+			break-inside: avoid;
 		}
 
 		span.issue,


### PR DESCRIPTION
Ref: https://github.com/w3c/csswg-drafts/commit/36fa01c9bbef63780164134211a509717255169c