### PR TITLE
Require FOs to have a public record in public-review-comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/6.3.07-candidate-recommendation.md
+++ b/.github/ISSUE_TEMPLATE/6.3.07-candidate-recommendation.md
@@ -34,7 +34,7 @@ assignees: plehegar
 [TODO: list of issues]
 
 # Formal Objections
-[TODO: link to those if any]
+[TODO: All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]
 
 # Implementation
 [TODO: any preliminary implementation information? exit criteria? minimum CR duration?]

--- a/.github/ISSUE_TEMPLATE/6.3.08.1-candidate-recommendation-snapshot.md
+++ b/.github/ISSUE_TEMPLATE/6.3.08.1-candidate-recommendation-snapshot.md
@@ -29,7 +29,7 @@ assignees: plehegar
 [TODO: list of issues]
 
 # Formal Objections
-[TODO: link to those if any]
+[TODO: All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]
 
 # Any changes in implementation information?
 [TODO: any preliminary implementation information? exit criteria? minimum CR duration?]

--- a/.github/ISSUE_TEMPLATE/6.3.09-proposed-recommendation.md
+++ b/.github/ISSUE_TEMPLATE/6.3.09-proposed-recommendation.md
@@ -28,6 +28,7 @@ assignees: plehegar
 # Issues addressed
 
 # Formal Objections
+[TODO: All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]
 
 # Implementation
 

--- a/.github/ISSUE_TEMPLATE/6.3.11.5-incorporating-amendments.md
+++ b/.github/ISSUE_TEMPLATE/6.3.11.5-incorporating-amendments.md
@@ -29,7 +29,7 @@ assignees: plehegar
 [TODO: include link to WBS, and any link to internal follow-up]
 
 # Formal Objections
-[TODO: link to those if any. All Formal Objects must have a public record]
+[TODO: All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]
 
 # Implementation
 [TODO: show adequate implementation experience of the proposed amendments]

--- a/.github/ISSUE_TEMPLATE/6.4.4-revising-w3c-statement.md
+++ b/.github/ISSUE_TEMPLATE/6.4.4-revising-w3c-statement.md
@@ -25,4 +25,4 @@ assignees: plehegar
 [TODO: include link to WBS, and any link to internal follow-up]
 
 # Formal Objections
-[TODO: link to those if any. All Formal Objects must have a public record]
+[TODO: link to those if any. All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]

--- a/.github/ISSUE_TEMPLATE/6.5.2-2-candidate-registry.md
+++ b/.github/ISSUE_TEMPLATE/6.5.2-2-candidate-registry.md
@@ -32,4 +32,4 @@ assignees: plehegar
 [TODO: list of issues]
 
 # Formal Objections
-[TODO: link to those if any]
+[TODO: All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]

--- a/.github/ISSUE_TEMPLATE/6.5.2-3-candidate-registry-snapshot.md
+++ b/.github/ISSUE_TEMPLATE/6.5.2-3-candidate-registry-snapshot.md
@@ -29,6 +29,6 @@ assignees: plehegar
 [TODO: list of issues]
 
 # Formal Objections
-[TODO: link to those if any]
+[TODO: All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]
 
 NOTE: Changes to the contents of registry tables that are in accordance with the registry definition do not need Team Verification

--- a/.github/ISSUE_TEMPLATE/6.5.2-4-registry.md
+++ b/.github/ISSUE_TEMPLATE/6.5.2-4-registry.md
@@ -28,5 +28,5 @@ assignees: plehegar
 [TODO: include link to WBS, and any link to internal follow-up]
 
 # Formal Objections
-[TODO: link to those if any. All Formal Objects must have a public record]
+[TODO: All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]
 

--- a/.github/ISSUE_TEMPLATE/6.5.2-5-registry-update.md
+++ b/.github/ISSUE_TEMPLATE/6.5.2-5-registry-update.md
@@ -25,6 +25,6 @@ assignees: plehegar
 [TODO: include link to WBS, and any link to internal follow-up]
 
 # Formal Objections
-[TODO: link to those if any. All Formal Objects must have a public record]
+[TODO: All Formal Objections must have a public record in [public-review-comments](https://lists.w3.org/Archives/Public/public-review-comments/)]
 
 NOTE: Changes to the contents of registry tables that are in accordance with the registry definition do not need Team Verification


### PR DESCRIPTION
This makes it clear where public records of formal objections are expected
