### PR TITLE
Added template for revised rec announcement

### DIFF
--- a/index.html
+++ b/index.html
@@ -2341,10 +2341,13 @@ Note: Info about features at risk is required in status section per pubrules
 
 			</ol>
 
-			<p>Please use the <a
-					href="https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Frec-announcement.html&amp;submit=Continue...">Team-only
-					transition
-					announcement template</a> as a starting point.</p>
+			<p data-profile="REC" data-rec='new'>Please use the <a
+				href="https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&amp;template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Frec-announcement.html&amp;submit=Continue...">Team-only
+				transition announcement template</a> as a starting point.</p>
+
+			<p data-profile="REC" data-rec='substantive|features'>Please use the <a
+				href="https://www.w3.org/new-doc-from-template?location=%2FTeam%2F&template=%2Fafs%2Fw3.org%2Fpub%2FWWW%2FTeam%2FTemplates%2Frevised-rec-announcement.html&submit=Continue...">Team-only
+				transition announcement template</a> as a starting point.</p>
 
 		</div>
 


### PR DESCRIPTION
This also removes the template announcement if it's OBSL or RSCND.
